### PR TITLE
Remove default chessboard styles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,6 @@
 
 <script>
 import { chessboard } from 'vue-chessboard';
-import 'vue-chessboard/dist/vue-chessboard.css';
 
 export default {
   name: 'App',


### PR DESCRIPTION
It's not needed since it's already included in the vue-chessboard component